### PR TITLE
fix(segmentation): fix non-opaque 3D segments transparency

### DIFF
--- a/trame_slicer/views/threed_view.py
+++ b/trame_slicer/views/threed_view.py
@@ -77,6 +77,9 @@ class ThreeDView(RenderView):
     ):
         super().__init__(*args, **kwargs)
 
+        self.renderer().SetUseDepthPeeling(True)
+        self.renderer().SetUseDepthPeelingForVolumes(True)
+
         factory = vtkMRMLThreeDViewDisplayableManagerFactory.GetInstance()
         factory.SetMRMLApplicationLogic(app_logic)
 


### PR DESCRIPTION
Fix bug where segments with a 3D opacity below 1.0 would not be rendered correctly in 3D views and appearr behind volumes