### PR TITLE
fix: fix cursor offset in views

### DIFF
--- a/trame_slicer/views/abstract_view.py
+++ b/trame_slicer/views/abstract_view.py
@@ -90,6 +90,7 @@ class AbstractView:
         self._render_window = vtkRenderWindow()
         self._render_window.ShowWindowOff()
         self._render_window.SetMultiSamples(8)
+        self._render_window.SetOffScreenRendering(1)
         self._render_window.AddRenderer(self._renderer)
 
         self._render_window_interactor = vtkRenderWindowInteractor()


### PR DESCRIPTION
Fix bug where the slicer cursor would be offset from the mouse cursor on Windows for screen with a pixel-ratio different from 1