### PR TITLE
fix(volumes_reader): add 'force' parameter to dcmread in _dcm_read_file

### DIFF
--- a/trame_slicer/core/volumes_reader.py
+++ b/trame_slicer/core/volumes_reader.py
@@ -342,7 +342,7 @@ class VolumesReader:
     @classmethod
     @lru_cache(dcm_read_lru_cache_size)
     def _dcm_read_file(cls, dcm_file):
-        return dcmread(dcm_file, stop_before_pixels=True)
+        return dcmread(dcm_file, stop_before_pixels=True, force=True)
 
     @classmethod
     @lru_cache(dcm_read_lru_cache_size)


### PR DESCRIPTION
For some of my dicom image, this papameter can load successfully.