### PR TITLE
fix(medical example): fix overflow in segmentation panel

### DIFF
--- a/examples/viewer_lib/ui/segmentation/segment_edit_area_ui.py
+++ b/examples/viewer_lib/ui/segmentation/segment_edit_area_ui.py
@@ -40,7 +40,11 @@ class SegmentEditAreaUI(VCard):
                         size="small",
                     )
 
-            with VCardText(v_if=(self._typed_state.name.is_extended,), classes="align-center"):
+            with VCardText(
+                v_if=(self._typed_state.name.is_extended,),
+                classes="align-center",
+                style="flex: 1; min-height: 0; overflow-y: auto;",
+            ):
                 DynamicSelect(
                     label="Editable Area",
                     state=self._typed_state.get_sub_state(self._typed_state.name.mask_select),
@@ -58,4 +62,5 @@ class SegmentEditAreaUI(VCard):
                     item_title="title",
                     hide_details=True,
                     density="compact",
+                    style="margin-top: 5px;",
                 )

--- a/examples/viewer_lib/ui/segmentation/segment_editor_ui.py
+++ b/examples/viewer_lib/ui/segmentation/segment_editor_ui.py
@@ -131,6 +131,7 @@ class SegmentEditorUI(FlexContainer):
                 SegmentEditAreaUI(
                     segment_edit_area_typed_state=self.sub_state(self._typed_state.name.segment_edit_area),
                     variant="flat",
+                    style="display: flex; flex-direction: column; min-height: 0;",
                 )
 
     def build_effect_buttons(self, all: bool = True, **kwargs):


### PR DESCRIPTION
Fix CSS problem in medical example segmentaiton panel resulting in overlap between elements