### PR TITLE
docs(medical example): change segment editor scroll style

### DIFF
--- a/examples/viewer_lib/ui/segmentation/draw_effect_ui.py
+++ b/examples/viewer_lib/ui/segmentation/draw_effect_ui.py
@@ -21,7 +21,7 @@ class DrawEffectUI(FlexContainer):
 
         with (
             self,
-            vuetify.VRow(style="margin-top: 20px;"),
+            vuetify.VRow(style="margin-top: 2px; margin-bottom: 0px;"),
             vuetify.VRadioGroup(
                 v_model=self._typed_state.name.brush_interaction_mode,
                 label="Brush interaction mode",

--- a/examples/viewer_lib/ui/segmentation/scissors_effect_ui.py
+++ b/examples/viewer_lib/ui/segmentation/scissors_effect_ui.py
@@ -28,7 +28,7 @@ class ScissorsEffectUI(FlexContainer):
 
         with self:
             with (
-                vuetify.VRow(style="margin-top: 20px;"),
+                vuetify.VRow(style="margin-top: 5px"),
                 vuetify.VRadioGroup(
                     v_model=self._typed_state.name.brush_interaction_mode,
                     label="Brush interaction mode",
@@ -49,7 +49,7 @@ class ScissorsEffectUI(FlexContainer):
                     vuetify.VRadioGroup(v_model=self._typed_state.name.range_mode, label="Cut mode", hide_details=True),
                 ):
                     enum_to_radio_buttons(self._typed_state, ScissorsEffectRangeMode)
-            with vuetify.VRow(style="margin-top: 20px; margin-left: 2px; margin-right: 2px;"):
+            with vuetify.VRow(style="margin-top: 20px; margin-left: 2px; margin-right: 2px; margin-bottom: 0px;"):
                 vuetify.VNumberInput(
                     v_model=self._typed_state.name.symmetric_distance,
                     label="Distance (mm)",

--- a/examples/viewer_lib/ui/segmentation/segment_display_ui.py
+++ b/examples/viewer_lib/ui/segmentation/segment_display_ui.py
@@ -58,7 +58,6 @@ class SegmentDisplayUI(VCard):
             with VCardText(
                 v_if=(self._typed_state.name.is_extended,),
                 classes="align-center",
-                style="flex: 1; min-height: 0; overflow-y: auto;",
             ):
                 Text("Display", subtitle=True)
                 with FlexContainer(

--- a/examples/viewer_lib/ui/segmentation/segment_edit_area_ui.py
+++ b/examples/viewer_lib/ui/segmentation/segment_edit_area_ui.py
@@ -30,20 +30,21 @@ class SegmentEditAreaUI(VCard):
         self._typed_state = segment_edit_area_typed_state
 
         with self:
-            with VCardItem():
+            with VCardItem(
+                click=f"{self._typed_state.name.is_extended} = !{self._typed_state.name.is_extended};",
+            ):
                 Text("Masking options", title=True)
                 with Template(v_slot_append=True):
                     VBtn(
                         icon=(f"{self._typed_state.name.is_extended} ? 'mdi-chevron-up' : 'mdi-chevron-down'",),
                         variant="flat",
-                        click=f"{self._typed_state.name.is_extended} = !{self._typed_state.name.is_extended};",
+                        click_stop=f"{self._typed_state.name.is_extended} = !{self._typed_state.name.is_extended};",
                         size="small",
                     )
 
             with VCardText(
                 v_if=(self._typed_state.name.is_extended,),
                 classes="align-center",
-                style="flex: 1; min-height: 0; overflow-y: auto;",
             ):
                 DynamicSelect(
                     label="Editable Area",

--- a/examples/viewer_lib/ui/segmentation/segment_editor_ui.py
+++ b/examples/viewer_lib/ui/segmentation/segment_editor_ui.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Any
 
+from trame.widgets import html
 from trame.widgets.vuetify3 import (
     VBtn,
     VCard,
@@ -106,35 +107,34 @@ class SegmentEditorUI(FlexContainer):
                 VDivider()
                 with VCard(
                     v_if=(self._typed_state.name.segment_list.active_segment_id,),
-                    classes="flex-grow-1",
                     variant="flat",
-                    style="display: flex; flex-direction: column; min-height: 0;",
+                    style="height:50%; display: flex; flex-direction: column;",
                 ):
                     with VCardItem(), FlexContainer(row=True, justify="space-between"):
                         self.build_effect_buttons()
                     VDivider(classes="mx-3")
-                    with VCardText(classes="align-center", style="flex: 1; min-height: 0; overflow-y: auto;"):
-                        self._register_effect_ui(SegmentationEffectPaint, PaintEffectUI)
-                        self._register_effect_ui(SegmentationEffectErase, PaintEffectUI)
-                        self._register_effect_ui(SegmentationEffectLogicalOperators, LogicalOperatorsEffectUI)
-                        self._register_effect_ui(SegmentationEffectThreshold, ThresholdEffectUI)
-                        self._register_effect_ui(SegmentationEffectIslands, IslandsEffectUI)
-                        self._register_effect_ui(SegmentationEffectDraw, DrawEffectUI)
-                        self._register_effect_ui(SegmentationEffectScissors, ScissorsEffectUI)
-                        self._register_effect_ui(SegmentationEffectSmoothing, SmoothingEffectUI)
-                VSpacer(v_else=True)
-                VDivider()
-                SegmentDisplayUI(
-                    typed_state=self.sub_state(self._typed_state.name.segment_display),
-                    variant="flat",
-                    style="display: flex; flex-direction: column; min-height: 0;",
-                )
-                VDivider()
-                SegmentEditAreaUI(
-                    segment_edit_area_typed_state=self.sub_state(self._typed_state.name.segment_edit_area),
-                    variant="flat",
-                    style="display: flex; flex-direction: column; min-height: 0;",
-                )
+                    with VCardText(style="display: flex; flex-direction: column; overflow-y: auto;"):
+                        with html.Div(style="margin-bottom: 10px;"):
+                            self._register_effect_ui(SegmentationEffectPaint, PaintEffectUI)
+                            self._register_effect_ui(SegmentationEffectErase, PaintEffectUI)
+                            self._register_effect_ui(SegmentationEffectLogicalOperators, LogicalOperatorsEffectUI)
+                            self._register_effect_ui(SegmentationEffectThreshold, ThresholdEffectUI)
+                            self._register_effect_ui(SegmentationEffectIslands, IslandsEffectUI)
+                            self._register_effect_ui(SegmentationEffectDraw, DrawEffectUI)
+                            self._register_effect_ui(SegmentationEffectScissors, ScissorsEffectUI)
+                            self._register_effect_ui(SegmentationEffectSmoothing, SmoothingEffectUI)
+                        VSpacer()
+                        with html.Div(classes="mt-auto"):
+                            VDivider()
+                            SegmentDisplayUI(
+                                typed_state=self.sub_state(self._typed_state.name.segment_display),
+                                variant="flat",
+                            )
+                            VDivider()
+                            SegmentEditAreaUI(
+                                segment_edit_area_typed_state=self.sub_state(self._typed_state.name.segment_edit_area),
+                                variant="flat",
+                            )
 
     def build_effect_buttons(self, all: bool = True, **kwargs):
         self._create_effect_button(


### PR DESCRIPTION
Group effect parameters, masking and rendering options in a single scrollable element
Allow expanding Mask options card by clicking on the title