### PR TITLE
fix(segmentation): Fix bug where effect parameter node could be None

### DIFF
--- a/trame_slicer/segmentation/abstract_segmentation_effect_brush.py
+++ b/trame_slicer/segmentation/abstract_segmentation_effect_brush.py
@@ -64,7 +64,7 @@ class AbstractSegmentationEffectBrush(SegmentationEffect, ABC):
         paint_parameters.paint_feedback_model_node.SetDisplayVisibility(self.is_active)
 
     def _get_paint_parameters(self) -> PaintEffectParameters:
-        return create_scripted_module_dataclass_proxy(PaintEffectParameters, self._param_node, self._scene)
+        return create_scripted_module_dataclass_proxy(PaintEffectParameters, self.get_parameter_node(), self._scene)
 
     def _create_pipeline(
         self, view_node: vtkMRMLAbstractViewNode, _parameter: vtkMRMLNode


### PR DESCRIPTION
Fix bug where segmentation effects' parameter node could be None when it should not, resulting in an error in the paint effect