### PR TITLE
fix: do not pass state var as trigger arguments

### DIFF
--- a/src/trame_slicer/app/logic/load_volume_logic.py
+++ b/src/trame_slicer/app/logic/load_volume_logic.py
@@ -21,13 +21,7 @@ class LoadVolumeLogic(BaseLogic[LoadVolumeState]):
         super().__init__(server, slicer_app, LoadVolumeState)
 
     def set_ui(self, ui: LoadVolumeUI):
-        ui.on_load_volume.connect(self._on_load_volume)
-
-    def _on_load_volume(self, files: list[dict], is_loading_state_name: str) -> None:
-        try:
-            self._load_volume_files(files)
-        finally:
-            self.state[is_loading_state_name] = False
+        ui.on_load_volume.connect(self._load_volume_files)
 
     def _load_volume_files(self, files: list[dict]) -> None:
         if not files:

--- a/src/trame_slicer/app/ui/load_volume_ui.py
+++ b/src/trame_slicer/app/ui/load_volume_ui.py
@@ -21,7 +21,7 @@ class LoadVolumeState:
 
 
 class LoadVolumeUI(FlexContainer):
-    on_load_volume = Signal(list[dict], str)
+    on_load_volume = Signal(list[dict])
 
     def __init__(self, **kwargs):
         super().__init__(row=True, **kwargs)
@@ -48,7 +48,7 @@ class LoadVolumeUI(FlexContainer):
 
 
 class LoadVolumeButton(FlexContainer):
-    on_load_volume = Signal(list[dict], str)
+    on_load_volume = Signal(list[dict])
 
     def __init__(self, name: str, load_directory: bool, icon: str, typed_state: TypedState[LoadVolumeItemsState]):
         super().__init__(justify="center", row=True, style="width: 50px; height: 50px;")
@@ -67,8 +67,10 @@ class LoadVolumeButton(FlexContainer):
                     f"{typed_state.name.loading_busy} = true; {typed_state.name.button_tooltip} = false;"
                     "trigger('"
                     f"{self.server.controller.trigger_name(self.on_load_volume.async_emit)}"
-                    f"', [$event.target.files, '{typed_state.name.loading_busy}']"
-                    ")"
+                    f"', [$event.target.files]"
+                    ").finally(() => {"
+                    f"{typed_state.name.loading_busy} = false;"
+                    "})"
                 ),
                 prepend_icon=icon,
                 multiple=not load_directory,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,6 +231,11 @@ def a_server_port():
 
 @pytest.fixture
 def a_server(render_interactive):
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+
     # Create a server with a unique ID to be sure that the created server is different for each run
     server = get_server(f"test_server_{uuid.uuid4()}", client_type="vue3")
 


### PR DESCRIPTION
Removed the name of the var that handles the file loading status from the `on_load_volume` signal. The loading status is entirely handled on the client side.
This is cleaner and the LoadVolumeLogic is easier to integrate with a custom LoadVolumeUI.