### PR TITLE
fix(ci): downgrade pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
     "pandas",
     "pixelmatch",
     "pytest",
-    "pytest-asyncio",
+    "pytest-asyncio==1.3.0",
     "pytest-cov",
     "pytest-playwright",
     "pytest-repeat",


### PR DESCRIPTION
Downgrade pytest-asyncio to fix CI error:
RuntimeError: There is no current event loop in thread 'MainThread'.